### PR TITLE
feat: add compute budget instructions

### DIFF
--- a/src/associated_token_account.zig
+++ b/src/associated_token_account.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const sol = @import("sol");
 const bincode = @import("bincode");
+const sol = @import("solana-program-sdk");
 
 pub const program_id = sol.PublicKey.comptimeFromBase58("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 

--- a/src/compute_budget.zig
+++ b/src/compute_budget.zig
@@ -20,9 +20,9 @@ pub fn requestHeapFrame(allocator: std.mem.Allocator, bytes: u32) !sol.Instructi
     });
 }
 
-pub fn setComputeUnitLimit(allocator: std.mem.Allocator, units: u32) !sol.Instruction {
+pub fn setComputeUnitLimit(allocator: std.mem.Allocator, compute_units: u32) !sol.Instruction {
     const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
-        .set_compute_unit_limit = .{ .units = units },
+        .set_compute_unit_limit = .{ .compute_units = compute_units },
     }, .{});
 
     return sol.Instruction.from(.{
@@ -68,7 +68,7 @@ pub const Instruction = union(enum(u8)) {
     },
     /// Set a specific compute unit limit that the transaction is allowed to consume.
     set_compute_unit_limit: struct {
-        units: u32,
+        compute_units: u32,
     },
     /// Set a compute unit price in "micro-lamports" to pay a higher transaction
     /// fee for higher transaction prioritization.

--- a/src/compute_budget.zig
+++ b/src/compute_budget.zig
@@ -1,0 +1,118 @@
+const std = @import("std");
+const sol = @import("solana-program-sdk");
+const bincode = @import("bincode");
+
+const Account = sol.Account;
+
+const ComputeBudget = @This();
+
+pub const id = sol.PublicKey.comptimeFromBase58("ComputeBudget111111111111111111111111111111");
+
+pub fn requestHeapFrame(allocator: std.mem.Allocator, params: struct { bytes: u32 }) !sol.Instruction {
+    const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
+        .request_heap_frame = .{ .bytes = params.bytes },
+    }, .{});
+    defer allocator.free(data);
+
+    return sol.Instruction.from(.{
+        .program_id = &id,
+        .accounts = &[_]Account.Param{},
+        .data = data,
+    });
+}
+
+pub fn setComputeUnitLimit(allocator: std.mem.Allocator, params: struct { units: u32 }) !sol.Instruction {
+    const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
+        .set_compute_unit_limit = .{ .units = params.units },
+    }, .{});
+    defer allocator.free(data);
+
+    return sol.Instruction.from(.{
+        .program_id = &id,
+        .accounts = &[_]Account.Param{},
+        .data = data,
+    });
+}
+
+pub fn setComputeUnitPrice(allocator: std.mem.Allocator, params: struct { micro_lamports: u64 }) !sol.Instruction {
+    const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
+        .set_compute_unit_price = .{ .micro_lamports = params.micro_lamports },
+    }, .{});
+    defer allocator.free(data);
+
+    return sol.Instruction.from(.{
+        .program_id = &id,
+        .accounts = &[_]Account.Param{},
+        .data = data,
+    });
+}
+
+pub fn setLoadedAccountsDataSizeLimit(allocator: std.mem.Allocator, params: struct { bytes: u32 }) !sol.Instruction {
+    const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
+        .set_loaded_accounts_data_size_limit = .{ .bytes = params.bytes },
+    }, .{});
+    defer allocator.free(data);
+
+    return sol.Instruction.from(.{
+        .program_id = &id,
+        .accounts = &[_]Account.Param{},
+        .data = data,
+    });
+}
+
+pub const Instruction = union(enum(u8)) {
+    // deprecated variant, reserved value.
+    unused,
+    /// Request a specific transaction-wide program heap region size in bytes.
+    /// The value requested must be a multiple of 1024. This new heap region
+    /// size applies to each program executed in the transaction, including all
+    /// calls to CPIs.
+    request_heap_frame: struct {
+        bytes: u32,
+    },
+    /// Set a specific compute unit limit that the transaction is allowed to consume.
+    set_compute_unit_limit: struct {
+        units: u32,
+    },
+    /// Set a compute unit price in "micro-lamports" to pay a higher transaction
+    /// fee for higher transaction prioritization.
+    set_compute_unit_price: struct {
+        micro_lamports: u64,
+    },
+    /// Set a specific transaction-wide account data size limit, in bytes, is allowed to load.
+    set_loaded_accounts_data_size_limit: struct {
+        bytes: u32,
+    },
+};
+
+test "build request heap frame ix" {
+    const ix = try requestHeapFrame(std.testing.allocator, .{ .bytes = 4_000 });
+
+    try std.testing.expect(ix.program_id.equals(id));
+    try std.testing.expectEqual(0, ix.accounts_len);
+    try std.testing.expectEqual(5, ix.data_len);
+}
+
+test "build set compute limit ix" {
+    const ix = try setComputeUnitLimit(std.testing.allocator, .{ .units = 1_400_000 });
+
+    try std.testing.expect(ix.program_id.equals(id));
+    try std.testing.expectEqual(0, ix.accounts_len);
+    try std.testing.expectEqual(5, ix.data_len);
+}
+
+test "build set compute unit price ix" {
+    const ix = try setComputeUnitPrice(std.testing.allocator, .{ .micro_lamports = 200_000 });
+
+    try std.testing.expect(ix.program_id.equals(id));
+    try std.testing.expectEqual(0, ix.accounts_len);
+    try std.testing.expectEqual(9, ix.data_len);
+}
+
+test "build set loaded accounts data-size limit ix" {
+    const ix = try setLoadedAccountsDataSizeLimit(std.testing.allocator, .{ .bytes = 1200 });
+
+    try std.testing.expect(ix.program_id.equals(id));
+    try std.testing.expectEqual(0, ix.accounts_len);
+    try std.testing.expectEqual(5, ix.data_len);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const associated_token_account = @import("associated_token_account.zig");
+pub const compute_budget = @import("compute_budget.zig");
 pub const system = @import("system.zig");
 pub const token = @import("token.zig");
 


### PR DESCRIPTION
I hope I understand your vision for that repository correctly, and compute_budget-related instructions should be located here.

Marking that MR as draft due to next reasons:
- can't compile that lib and properly check due to compilation issues in the bincode dependency
- want to add some tests and documentation
- lint & clean-up the MR