### PR TITLE
refactor: pass allocator as param

### DIFF
--- a/src/associated_token_account.zig
+++ b/src/associated_token_account.zig
@@ -2,7 +2,8 @@ const std = @import("std");
 const bincode = @import("bincode");
 const sol = @import("solana-program-sdk");
 
-pub const program_id = sol.PublicKey.comptimeFromBase58("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+const AssociatedTokenProgram = @This();
+pub const id = sol.PublicKey.comptimeFromBase58("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
 pub const Instruction = union(enum(u8)) {
     /// Creates an associated token account for the given wallet address and token mint
@@ -53,10 +54,10 @@ pub fn getAssociatedTokenAccountAddressWithProgramId(wallet_address: sol.PublicK
 }
 
 pub fn getAssociatedTokenAccountAddressAndBumpSeed(wallet_address: sol.PublicKey, mint_address: sol.PublicKey, token_program_id: sol.PublicKey) !sol.ProgramDerivedAddress {
-    return sol.PublicKey.findProgramAddress(.{ wallet_address, token_program_id, mint_address }, program_id);
+    return sol.PublicKey.findProgramAddress(.{ wallet_address, token_program_id, mint_address }, id);
 }
 
-pub fn createAccount(account: sol.Account.Info, params: struct {
+pub fn createAccount(allocator: std.mem.Allocator, account: sol.Account.Info, params: struct {
     funder: sol.Account.Info,
     owner: sol.Account.Info,
     mint: sol.Account.Info,
@@ -65,11 +66,11 @@ pub fn createAccount(account: sol.Account.Info, params: struct {
     rent: sol.Account.Info,
     seeds: []const []const []const u8 = &.{},
 }) !void {
-    const data = try bincode.writeAlloc(sol.allocator, Instruction.create, .{});
-    defer sol.allocator.free(data);
+    const data = try bincode.writeAlloc(allocator, AssociatedTokenProgram.Instruction.create, .{});
+    defer allocator.free(data);
 
     const instruction = sol.Instruction.from(.{
-        .program_id = &program_id,
+        .program_id = &id,
         .accounts = &[_]sol.Account.Param{
             .{ .id = params.funder.id, .is_writable = true, .is_signer = true },
             .{ .id = account.id, .is_writable = true, .is_signer = false },
@@ -93,7 +94,7 @@ pub fn createAccount(account: sol.Account.Info, params: struct {
     }, params.seeds);
 }
 
-pub fn createIdempotentAccount(account: sol.Account.Info, params: struct {
+pub fn createIdempotentAccount(allocator: std.mem.Allocator, account: sol.Account.Info, params: struct {
     funder: sol.Account.Info,
     owner: sol.Account.Info,
     mint: sol.Account.Info,
@@ -102,11 +103,11 @@ pub fn createIdempotentAccount(account: sol.Account.Info, params: struct {
     associated_token_program: sol.Account.Info,
     seeds: []const []const []const u8 = &.{},
 }) !void {
-    const data = try bincode.writeAlloc(sol.allocator, Instruction.create_idempotent, .{});
-    defer sol.allocator.free(data);
+    const data = try bincode.writeAlloc(allocator, AssociatedTokenProgram.Instruction.create_idempotent, .{});
+    defer allocator.free(data);
 
     const instruction = sol.Instruction.from(.{
-        .program_id = &program_id,
+        .program_id = &id,
         .accounts = &[_]sol.Account.Param{
             .{ .id = params.funder.id, .is_writable = true, .is_signer = true },
             .{ .id = account.id, .is_writable = true, .is_signer = false },
@@ -124,6 +125,45 @@ pub fn createIdempotentAccount(account: sol.Account.Info, params: struct {
         params.owner,
         params.mint,
         params.system_program,
+        params.token_program,
+        params.associated_token_program,
+    }, params.seeds);
+}
+
+pub fn recoverNestedAccount(allocator: std.mem.Allocator, account: sol.Account.Info, params: struct {
+    nested_mint: sol.Account.Info,
+    destination_associated_account: sol.Account.Info,
+    owner_associated_account: sol.Account.Info,
+    owner_mint: sol.Account.Info,
+    owner: sol.Account.Info,
+    token_program: sol.Account.Info,
+    associated_token_program: sol.Account.Info,
+    seeds: []const []const []const u8 = &.{},
+}) !void {
+    const data = try bincode.writeAlloc(allocator, AssociatedTokenProgram.Instruction.recover_nested, .{});
+    defer allocator.free(data);
+
+    const instruction = sol.Instruction.from(.{
+        .program_id = &id,
+        .accounts = &[_]sol.Account.Param{
+            .{ .id = params.account.id, .is_writable = true, .is_signer = false },
+            .{ .id = params.nested_mint.id, .is_writable = false, .is_signer = false },
+            .{ .id = params.destination_associated_account.id, .is_writable = true, .is_signer = false },
+            .{ .id = params.owner_associated_account.id, .is_writable = false, .is_signer = false },
+            .{ .id = params.owner_mint.id, .is_writable = false, .is_signer = false },
+            .{ .id = params.owner.id, .is_writable = true, .is_signer = true },
+            .{ .id = params.token_program.id, .is_writable = false, .is_signer = false },
+        },
+        .data = data,
+    });
+
+    try instruction.invokeSigned(&.{
+        account,
+        params.nested_mint,
+        params.destination_associated_account,
+        params.owner_associated_account,
+        params.owner_mint,
+        params.owner,
         params.token_program,
         params.associated_token_program,
     }, params.seeds);

--- a/src/system.zig
+++ b/src/system.zig
@@ -3,14 +3,12 @@ const bincode = @import("bincode");
 const sol = @import("solana-program-sdk");
 
 const Account = sol.Account;
-const allocator = sol.allocator;
-const ix = sol.instruction;
 const PublicKey = sol.PublicKey;
 
 const SystemProgram = @This();
 pub const id = PublicKey.comptimeFromBase58("11111111111111111111111111111111");
 
-pub fn createAccount(account: Account.Info, params: struct {
+pub fn createAccount(allocator: std.mem.Allocator, account: Account.Info, params: struct {
     payer: Account.Info,
     lamports: u64,
     space: u64,
@@ -26,7 +24,7 @@ pub fn createAccount(account: Account.Info, params: struct {
     }, .{});
     defer allocator.free(data);
 
-    const instruction = ix.Instruction.from(.{
+    const instruction = sol.Instruction.from(.{
         .program_id = &id,
         .accounts = &[_]Account.Param{
             .{ .id = params.payer.id, .is_writable = true, .is_signer = true },
@@ -38,7 +36,7 @@ pub fn createAccount(account: Account.Info, params: struct {
     try instruction.invokeSigned(&.{ params.payer, account }, params.seeds);
 }
 
-pub fn transfer(params: struct {
+pub fn transfer(allocator: std.mem.Allocator, params: struct {
     from: Account.Info,
     to: Account.Info,
     lamports: u64,
@@ -49,7 +47,7 @@ pub fn transfer(params: struct {
     }, .{});
     defer allocator.free(data);
 
-    const instruction = ix.Instruction.from(.{
+    const instruction = sol.Instruction.from(.{
         .program_id = &id,
         .accounts = &[_]Account.Param{
             .{ .id = params.from.id, .is_writable = true, .is_signer = true },
@@ -61,7 +59,7 @@ pub fn transfer(params: struct {
     try instruction.invokeSigned(&.{ params.from, params.to }, params.seeds);
 }
 
-pub fn allocate(account: Account.Info, space: u64, params: struct {
+pub fn allocate(allocator: std.mem.Allocator, account: Account.Info, space: u64, params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     const data = try bincode.writeAlloc(allocator, SystemProgram.Instruction{
@@ -69,7 +67,7 @@ pub fn allocate(account: Account.Info, space: u64, params: struct {
     }, .{});
     defer allocator.free(data);
 
-    const instruction = ix.Instruction.from(.{
+    const instruction = sol.Instruction.from(.{
         .program_id = &id,
         .accounts = &[_]Account.Param{
             .{ .id = account.id, .is_writable = true, .is_signer = true },
@@ -80,7 +78,7 @@ pub fn allocate(account: Account.Info, space: u64, params: struct {
     try instruction.invokeSigned(&.{account}, params.seeds);
 }
 
-pub fn assign(account: Account.Info, owner_id: PublicKey, params: struct {
+pub fn assign(allocator: std.mem.Allocator, account: Account.Info, owner_id: PublicKey, params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     const data = try bincode.writeAlloc(allocator, SystemProgram.Instruction{
@@ -88,7 +86,7 @@ pub fn assign(account: Account.Info, owner_id: PublicKey, params: struct {
     }, .{});
     defer allocator.free(data);
 
-    const instruction = ix.Instruction.from(.{
+    const instruction = sol.Instruction.from(.{
         .program_id = &id,
         .accounts = &[_]Account.Param{
             .{ .id = account.id, .is_writable = true, .is_signer = true },


### PR DESCRIPTION
- [x] ability to choose and pass `allocator` to the functions.
- [x]  the same and consistent style for **ata** & **spl-token** as system program
- [x] add (I assume, previously forgotten) `recover_nested` ix in ata program