### PR TITLE
Bump Zig to 0.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.0
       - run: zig build test --summary all
   lint:
     runs-on: ubuntu-latest
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.0
       - run: zig fmt --check .

--- a/build.zig
+++ b/build.zig
@@ -17,14 +17,14 @@ pub fn build(b: *std.Build) void {
 
     const dep_opts = .{ .target = target, .optimize = optimize };
     // Export self as a module
-    const sol_lib_mod = b.addModule("solana-program-library", .{
+    const sol_lib_mod = b.addModule("solana_program_library", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const lib = b.addStaticLibrary(.{
-        .name = "solana-program-library",
+        .name = "solana_program_library",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
         .root_source_file = b.path("src/root.zig"),
@@ -33,10 +33,10 @@ pub fn build(b: *std.Build) void {
     });
 
     // Adding it as a module
-    const solana_dep = b.dependency("solana-program-sdk", dep_opts);
-    const solana_mod = solana_dep.module("solana-program-sdk");
-    lib.root_module.addImport("solana-program-sdk", solana_mod);
-    sol_lib_mod.addImport("solana-program-sdk", solana_mod);
+    const solana_dep = b.dependency("solana_program_sdk", dep_opts);
+    const solana_mod = solana_dep.module("solana_program_sdk");
+    lib.root_module.addImport("solana_program_sdk", solana_mod);
+    sol_lib_mod.addImport("solana_program_sdk", solana_mod);
 
     const bincode_dep = b.dependency("bincode", .{
         .target = target,
@@ -58,7 +58,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    lib_unit_tests.root_module.addImport("solana-program-sdk", solana_mod);
+    lib_unit_tests.root_module.addImport("solana_program_sdk", solana_mod);
     lib_unit_tests.root_module.addImport("bincode", bincode_mod);
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,46 +1,22 @@
 .{
-    // This is the default name used by packages depending on this one. For
-    // example, when a user runs `zig fetch --save <url>`, this field is used
-    // as the key in the `dependencies` table. Although the user can choose a
-    // different name, most users will stick with this provided value.
-    //
-    // It is redundant to include "zig" in this name because it is already
-    // within the Zig package namespace.
-    .name = "solana-program-library",
+    .fingerprint = 0xa4b85d3595fe4ad7,
+    .name = .solana_program_library,
 
-    // This is a [Semantic Version](https://semver.org/).
-    // In a future version of Zig it will be used for package deduplication.
-    .version = "0.14.0",
+    .version = "0.15.0",
 
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
 
-    // This field is optional.
-    // Each dependency must either provide a `url` and `hash`, or a `path`.
-    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
-    // Once all dependencies are fetched, `zig build` no longer requires
-    // internet connectivity.
     .dependencies = .{
         .bincode = .{
-            .url = "https://github.com/joncinque/bincode-zig/archive/refs/tags/v0.13.0.tar.gz",
-            .hash = "12204503a7598b452f311534ba8f9d5dc158403d19a17be89eb7a04ba01a6ebb8b45",
+            .url = "https://github.com/joncinque/bincode-zig/archive/refs/tags/v0.14.0.tar.gz",
+            .hash = "bincode-0.14.0-LYspxE5uAABpwu-W95yJ9swZ3YhGkgbwaGwVjzNZGNXH",
         },
-        .@"solana-program-sdk" = .{
-            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.0.tar.gz",
-            .hash = "1220bdfa4ea1ab6330959ce4bc40feb5b39a7f98923a266a94b69e27fd20c3526786",
+        .solana_program_sdk = .{
+            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.16.0.tar.gz",
+            .hash = "solana_program_sdk-0.16.0-wGj9UFDgAAA31EfM9LV-cmDP5BctyNwEVvyEWtZ1QPkj",
         },
     },
 
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package. Only files listed here will remain on disk
-    // when using the zig package manager. As a rule of thumb, one should list
-    // files required for compilation plus any license(s).
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/associated_token_account.zig
+++ b/src/associated_token_account.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const bincode = @import("bincode");
-const sol = @import("solana-program-sdk");
+const sol = @import("solana_program_sdk");
 
 const AssociatedTokenAccountProgram = @This();
 pub const id = sol.PublicKey.comptimeFromBase58("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
@@ -68,7 +68,7 @@ pub fn createAccount(params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     var data: [1]u8 = undefined;
-    _ = try bincode.writeToSlice(&data, AssociatedTokenAccountProgram.Instruction.create, .{});
+    _ = try bincode.writeToSlice(&data, AssociatedTokenAccountProgram.Instruction.create, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -106,7 +106,7 @@ pub fn createIdempotentAccount(params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     var data: [1]u8 = undefined;
-    _ = try bincode.writeToSlice(&data, AssociatedTokenAccountProgram.Instruction.create_idempotent, .{});
+    _ = try bincode.writeToSlice(&data, AssociatedTokenAccountProgram.Instruction.create_idempotent, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -144,7 +144,7 @@ pub fn recoverNestedAccount(params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     var data: [1]u8 = undefined;
-    _ = try bincode.writeToSlice(&data, AssociatedTokenAccountProgram.Instruction.recover_nested, .{});
+    _ = try bincode.writeToSlice(&data, AssociatedTokenAccountProgram.Instruction.recover_nested, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,

--- a/src/compute_budget.zig
+++ b/src/compute_budget.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const sol = @import("solana-program-sdk");
+const sol = @import("solana_program_sdk");
 const bincode = @import("bincode");
 
 const Account = sol.Account;
@@ -11,7 +11,7 @@ pub const id = sol.PublicKey.comptimeFromBase58("ComputeBudget111111111111111111
 pub fn requestHeapFrame(allocator: std.mem.Allocator, bytes: u32) !sol.Instruction {
     const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
         .request_heap_frame = .{ .bytes = bytes },
-    }, .{});
+    }, .default);
 
     return sol.Instruction.from(.{
         .program_id = &id,
@@ -23,7 +23,7 @@ pub fn requestHeapFrame(allocator: std.mem.Allocator, bytes: u32) !sol.Instructi
 pub fn setComputeUnitLimit(allocator: std.mem.Allocator, compute_units: u32) !sol.Instruction {
     const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
         .set_compute_unit_limit = .{ .compute_units = compute_units },
-    }, .{});
+    }, .default);
 
     return sol.Instruction.from(.{
         .program_id = &id,
@@ -35,7 +35,7 @@ pub fn setComputeUnitLimit(allocator: std.mem.Allocator, compute_units: u32) !so
 pub fn setComputeUnitPrice(allocator: std.mem.Allocator, micro_lamports: u64) !sol.Instruction {
     const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
         .set_compute_unit_price = .{ .micro_lamports = micro_lamports },
-    }, .{});
+    }, .default);
 
     return sol.Instruction.from(.{
         .program_id = &id,
@@ -47,7 +47,7 @@ pub fn setComputeUnitPrice(allocator: std.mem.Allocator, micro_lamports: u64) !s
 pub fn setLoadedAccountsDataSizeLimit(allocator: std.mem.Allocator, bytes: u32) !sol.Instruction {
     const data = try bincode.writeAlloc(allocator, ComputeBudget.Instruction{
         .set_loaded_accounts_data_size_limit = .{ .bytes = bytes },
-    }, .{});
+    }, .default);
 
     return sol.Instruction.from(.{
         .program_id = &id,

--- a/src/system.zig
+++ b/src/system.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const bincode = @import("bincode");
-const sol = @import("solana-program-sdk");
+const sol = @import("solana_program_sdk");
 
 const Account = sol.Account;
 const PublicKey = sol.PublicKey;
@@ -23,7 +23,7 @@ pub fn createAccount(params: struct {
             .space = params.space,
             .owner_id = params.owner_id,
         },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -46,7 +46,7 @@ pub fn transfer(params: struct {
     var data: [12]u8 = undefined;
     _ = try bincode.writeToSlice(&data, SystemProgram.Instruction{
         .transfer = .{ .lamports = params.lamports },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -68,7 +68,7 @@ pub fn allocate(params: struct {
     var data: [12]u8 = undefined;
     _ = try bincode.writeToSlice(&data, SystemProgram.Instruction{
         .allocate = .{ .space = params.space },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -89,7 +89,7 @@ pub fn assign(params: struct {
     var data: [36]u8 = undefined;
     _ = try bincode.writeToSlice(&data, SystemProgram.Instruction{
         .assign = .{ .owner_id = params.owner_id },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -249,7 +249,7 @@ test "SystemProgram.Instruction: serialize and deserialize" {
     var buffer = std.ArrayList(u8).init(std.testing.allocator);
     defer buffer.deinit();
 
-    inline for (.{ .{}, bincode.Params.legacy, bincode.Params.standard }) |params| {
+    inline for (.{ bincode.Params.default, bincode.Params.legacy, bincode.Params.standard }) |params| {
         inline for (.{
             SystemProgram.Instruction{
                 .create_account = .{

--- a/src/token.zig
+++ b/src/token.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const sol = @import("solana-program-sdk");
+const sol = @import("solana_program_sdk");
 const bincode = @import("bincode");
 
 const TokenProgram = @This();
@@ -29,7 +29,7 @@ pub const Error = error{
 };
 
 pub fn getErrorFromCode(code: u32) (Error || error{Unknown})!void {
-    inline for (@typeInfo(Error).ErrorSet.?, 0..) |err, i| {
+    inline for (@typeInfo(Error).error_set.?, 0..) |err, i| {
         if (i == code) {
             return @field(Error, err.name);
         }
@@ -507,11 +507,11 @@ pub const Mint = struct {
     freeze_authority: bincode.Option(sol.PublicKey),
 
     pub fn decode(bytes: []const u8) !Mint {
-        return bincode.readFromSlice(undefined, Mint, bytes, .{});
+        return bincode.readFromSlice(undefined, Mint, bytes, .default);
     }
 
     pub fn writeTo(self: Mint, writer: anytype) !void {
-        return bincode.write(writer, self, .{});
+        return bincode.write(writer, self, .default);
     }
 };
 
@@ -534,11 +534,11 @@ pub const Account = struct {
     close_authority_id: bincode.Option(sol.PublicKey),
 
     pub fn decode(bytes: []const u8) !Account {
-        return bincode.readFromSlice(undefined, Account, bytes, .{});
+        return bincode.readFromSlice(undefined, Account, bytes, .default);
     }
 
     pub fn writeTo(self: Account, writer: anytype) !void {
-        return bincode.write(writer, self, .{});
+        return bincode.write(writer, self, .default);
     }
 };
 
@@ -574,7 +574,7 @@ pub fn initializeMint(params: struct {
             .mint_authority_id = params.mint_authority_id,
             .freeze_authority_id = params.freeze_authority_id,
         },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -596,7 +596,7 @@ pub fn initializeAccount(params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     var data: [1]u8 = undefined;
-    _ = try bincode.writeToSlice(&data, TokenProgram.Instruction.initialize_account, .{});
+    _ = try bincode.writeToSlice(&data, TokenProgram.Instruction.initialize_account, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -625,7 +625,7 @@ pub fn transfer(params: struct {
     var data: [9]u8 = undefined;
     _ = try bincode.writeToSlice(&data, TokenProgram.Instruction{
         .transfer = .{ .amount = params.amount },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -656,7 +656,7 @@ pub fn setAuthority(params: struct {
             .authority_type = params.authority_type,
             .new_authority_id = params.new_authority_id,
         },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -685,7 +685,7 @@ pub fn burn(params: struct {
         .burn = .{
             .amount = params.amount,
         },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -715,7 +715,7 @@ pub fn mintTo(params: struct {
         .mint_to = .{
             .amount = params.amount,
         },
-    }, .{});
+    }, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -737,7 +737,7 @@ pub fn closeAccount(params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     var data: [1]u8 = undefined;
-    _ = try bincode.writeToSlice(&data, TokenProgram.Instruction.close_account, .{});
+    _ = try bincode.writeToSlice(&data, TokenProgram.Instruction.close_account, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,
@@ -762,7 +762,7 @@ pub fn freezeAccount(params: struct {
     seeds: []const []const []const u8 = &.{},
 }) !void {
     var data: [1]u8 = undefined;
-    _ = try bincode.writeToSlice(&data, TokenProgram.Instruction.freeze_account, .{});
+    _ = try bincode.writeToSlice(&data, TokenProgram.Instruction.freeze_account, .default);
 
     const instruction = sol.Instruction.from(.{
         .program_id = &id,


### PR DESCRIPTION
* Update versions in CI and build.zig.zon
* Use a fingerprint + enum value for the name of the package
* Use lower-cased enum variants
* Use `bincode.Params.default` instead of an empty struct